### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.changeset/strong-pets-argue.md
+++ b/.changeset/strong-pets-argue.md
@@ -1,0 +1,5 @@
+---
+"geo-invaders": patch
+---
+
+fix: fix vulnerability for code scanning alert no. 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@
 
 name: "Lint"
 
+permissions:
+    contents: read
+
 on:
     pull_request:
         branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/notthebestdev/geo-invaders/security/code-scanning/1](https://github.com/notthebestdev/geo-invaders/security/code-scanning/1)

The general fix is to explicitly define `permissions` for the workflow/job so that the `GITHUB_TOKEN` has only the minimal scopes required. For this lint workflow, the steps only need to read repository contents to check out the code; they do not need to write to the repo, issues, or pull requests.

The best way to fix this without changing functionality is to add a `permissions` block at the workflow root (top-level, alongside `name` and `on`) that sets `contents: read`. This will apply to all jobs in the workflow (here only `lint`) and ensure the token is limited. Concretely, in `.github/workflows/lint.yml`, insert:

```yaml
permissions:
    contents: read
```

between the `name: "Lint"` and the `on:` block. No additional imports or definitions are required, and the existing steps remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
